### PR TITLE
Insert conversion to string in GetSecret function.

### DIFF
--- a/kubernetes_secrets_reader.go
+++ b/kubernetes_secrets_reader.go
@@ -33,8 +33,9 @@ func (s *KubernetesSecretsReader) GetSecret(ctx context.Context, secretName stri
 	}
 
 	data := make(map[string]interface{})
+	// Get the data fields as strings
 	for key, value := range secret.Data {
-		data[key] = value
+		data[key] = string(value)
 	}
 
 	return data, nil


### PR DESCRIPTION
Add missing conversion to string on the secret data. Without this conversion copy module and arrow module fail to read data from s3 using dateset credentials retrieved with this plugin.